### PR TITLE
Complétion de la définition de la méthode sheet.prompt()

### DIFF
--- a/fr/system-builder/scripting/prompt.md
+++ b/fr/system-builder/scripting/prompt.md
@@ -27,10 +27,11 @@ sheet.get('attack').on('click', function() {
 }); 
 ```
 
-# `sheet.prompt(title, view, callback)`
+# `sheet.prompt(title, view, callback, callbackInit)`
 **`title`**, type: `string` *`required`*, The title of the prompt window.
 **`view`**, type: `string` *`required`*, The ID of the view to use.
 **`callback`**, type: `Function` *`required`*, The callback to get the data once the user click the "next" button. The first argument is the view's data.
+**`callbackInit`**, type: `Function`, The callback called when opening the prompt which allows to modify elements of the prompt view from information coming from the sheet which calls `sheet.prompt(...)`
 
 # `Prompt(title, view, callback)`
 > This stand-alone function has been deprecated, use sheet.prompt() instead

--- a/fr/system-builder/scripting/sheet.md
+++ b/fr/system-builder/scripting/sheet.md
@@ -50,7 +50,7 @@ values = {
 */
 ```
 
-## `prompt(title, view, callback)`
+## `prompt(title, view, callback, callbackInit)`
 See: [Prompt API](/en/system-builder/scripting/prompt)
 
 ## `id()`

--- a/system-builder/scripting/prompt.md
+++ b/system-builder/scripting/prompt.md
@@ -27,10 +27,11 @@ sheet.get('attack').on('click', function() {
 }); 
 ```
 
-# `sheet.prompt(title, view, callback)`
+# `sheet.prompt(title, view, callback, callbackInit)`
 **`title`**, type: `string` *`required`*, The title of the prompt window.
 **`view`**, type: `string` *`required`*, The ID of the view to use.
 **`callback`**, type: `Function` *`required`*, The callback to get the data once the user click the "next" button. The first argument is the view's data.
+**`callbackInit`**, type: `Function`, The callback called when opening the prompt which allows to modify elements of the prompt view from information coming from the sheet which calls `sheet.prompt(...)`
 
 # `Prompt(title, view, callback)`
 > This stand-alone function has been deprecated, use sheet.prompt() instead

--- a/system-builder/scripting/sheet.md
+++ b/system-builder/scripting/sheet.md
@@ -50,7 +50,7 @@ values = {
 */
 ```
 
-## `prompt(title, view, callback)`
+## `prompt(title, view, callback, callbackInit)`
 See: [Prompt API](/en/system-builder/scripting/prompt)
 
 ## `id()`


### PR DESCRIPTION
Ajout de la description du quatrième paramètre optionnel en entrée de sheet.prompt() qui permet de modifier le contenu de la vue prompt affichée à l'ouverture à partir d'informations issues de la feuille appelante.
Par contre, est-ce normal que sur github les retours à la ligne ne se fassent pas comme sur le wiki lets role ? C'est valable pour les 4 fichiers que j'ai modifié comme pour tous ceux que j'ai ouvert.