### PR TITLE
corrections

### DIFF
--- a/fr/system-builder.md
+++ b/fr/system-builder.md
@@ -44,7 +44,7 @@ Voici la documentation du **System Builder** de Let's Role. Vous trouverez ici t
 * [Icon](/system-builder/component/icon) 
 {.links-list}
 ---
-* [Editer directement l'arboressence à la source](/en/system-builder/scripting/source-editor) 
+* [Editer directement l'arboressence à la source](/fr/system-builder/scripting/source-editor) 
 {.links-list}
 
 # Scripter

--- a/fr/system-builder/scripting/tables.md
+++ b/fr/system-builder/scripting/tables.md
@@ -23,7 +23,7 @@ Représente une table.
 
 ## `get(id)`
 **`id`**, type: `string`, L'identifiant de la ligne.
-Retourne : [`Component`](/fr/system-builder/scripting/component).
+Retourne : `Object|null`.
 
 Exemple :
 ```javascript


### PR DESCRIPTION
correction d'un autre lien que je n'avais pas vu qui redirigeait du wiki francais vers le wiki anglais
correction du type de retour de Table.get() (erreur de copier/coller)