### PR TITLE
Indemmar bug delet

### DIFF
--- a/fr/system-builder/scripting/utilities.md
+++ b/fr/system-builder/scripting/utilities.md
@@ -7,7 +7,7 @@ tags:
 editor: undefined
 ---
 
-# `log(var1, var2, ...)`
+# `log(var1)`
 Retourne `void`.
 Trace le contenu des variables dans la console.
 

--- a/system-builder/scripting/utilities.md
+++ b/system-builder/scripting/utilities.md
@@ -7,7 +7,7 @@ tags:
 editor: undefined
 ---
 
-# `log(var1, var2, ...)`
+# `log(var1)`
 Log variables to the console.
 
 # `//region` `//endregion`


### PR DESCRIPTION
Un bug empêche l'usage de multiple variable dans la fonction log
pour éviter toute confusion, Tiamate souhaite supprimer l'information temporairement.